### PR TITLE
docs: Improve README clarity and add Windows command

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,14 @@ Create a multi-language translation pipeline:
 
 > **💡 Tip**: Set your OpenAI API key as a system environment variable:
 >
+> **macOS / Linux (Bash)**
 > ```bash
 > export OPENAI_API_KEY="your-api-key-here"
+> ```
+>
+> **Windows (Command Prompt)**
+> ```bash
+> set OPENAI_API_KEY="your-api-key-here"
 > ```
 
 ## 📋 CLI Commands


### PR DESCRIPTION
This PR updates the "Prerequisites" section in README.md to include the command for setting the OPENAI_API_KEY environment variable on Windows. This ensures users on all major operating systems have clear and complete setup instructions.