### PR TITLE
feat: Add CLI version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Create a multi-language translation pipeline:
 | `multisync --config=file.json --verbose` | Run with verbose logging        |
 | `multisync --setup`                      | Run system setup and validation |
 | `multisync --help`                       | Show help information           |
+| `multisync -v, --version`                | Show version number             |
 
 ## 🛠️ Development
 

--- a/cli.mjs
+++ b/cli.mjs
@@ -2,6 +2,9 @@
 // Main CLI entry point for multisync
 import { validateOpenAIKey, validateNodeEnvironment } from './validator.mjs';
 import { runParser } from './parser.mjs';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 function showHelp() {
   console.log(`
@@ -12,6 +15,7 @@ Options:
   --config=PATH        Configuration file path (required for execution)
   --verbose            Enable verbose logging
   --help               Show this help message
+  -v, --version        Show the version number
 
 Examples:
   multisync              # Start interactive mode
@@ -21,12 +25,21 @@ Examples:
 `);
 }
 
+function showVersion() {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+  const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
+  console.log(pkg.version);
+}
+
 export function parseArgs(args) {
   const flags = {};
 
   for (const arg of args) {
     if (arg === '--help') {
       flags.help = true;
+    } else if (arg === '--version' || arg === '-v') {
+      flags.version = true;
     } else if (arg === '--setup') {
       flags.setup = true;
     } else if (arg === '--verbose') {
@@ -112,6 +125,11 @@ async function main() {
 
     if (flags.help) {
       showHelp();
+      return;
+    }
+
+    if (flags.version) {
+      showVersion();
       return;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "multisync",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "multisync",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "1.0.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@openai/agents": "^0.0.17",
         "zod": "^3.25.76"


### PR DESCRIPTION
This pull request introduces a new version command to the CLI, allowing users to quickly check the installed version of multisync.

Changes
- Added -v and --version flags to cli.mjs to display the version from package.json.

- Updated README.md to include the new command in the CLI documentation.