### PR TITLE
fix test script on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "multisync",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "multisync",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@openai/agents": "^0.0.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "multisync",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Multi-agent workflow orchestrator for AI-powered task automation",
   "keywords": [
     "ai",


### PR DESCRIPTION
This PR introduces a fix for the test script on Windows


### The issue
```
the test script ran the POSIX shell shim ./node_modules/.bin/jest with Node, so on Windows Node tried to parse a bash script (basedir=$(dirname ...)) and crashed.
```